### PR TITLE
add default_url env var to MMT container task definitions

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -124,6 +124,12 @@ aws ssm put-parameter \
     --overwrite \
     --name "/${MMT_STACK_STAGE}-maap-mmt/MMT_ROOT" \
     --value "https://mmt.${MMT_STACK_STAGE}.maap-project.org"
+
+aws ssm put-parameter \
+    --type "String" \
+    --overwrite \
+    --name "/${MMT_STACK_STAGE}-maap-mmt/MMT_HOST" \
+    --value "mmt.${MMT_STACK_STAGE}.maap-project.org"
 ```
 
 ### 3. Set deployment configuration

--- a/deployment/cdk/app.py
+++ b/deployment/cdk/app.py
@@ -277,6 +277,8 @@ class MmtStack(core.Stack):
             self, f"/{stack_name}/CMR_ROOT")
         task_env["MMT_ROOT"] = ssm.StringParameter.value_for_string_parameter(
             self, f"/{stack_name}/MMT_ROOT")
+        task_env["default_url"] = ssm.StringParameter.value_for_string_parameter(
+            self, f"/{stack_name}/MMT_HOST")
         task_env["CUMULUS_REST_API"] = ssm.StringParameter.value_for_string_parameter(
             self, f"/{stack_name}/CUMULUS_REST_API")
 


### PR DESCRIPTION
The Rails configuration requires the `default_url` environment variable:

https://github.com/MAAP-Project/mmt/blob/master/config/environments/production.rb#L111

Without this environment variable, we were getting errors on certain pages in MMT like this one:

```
F, [2022-01-20T18:55:04.571310 #45] FATAL -- : [348c55e7-8921-4750-9928-b03174ca5e16] ActionView::Template::Error (Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true):
```