### PR TITLE
Add SES mail delivery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ gem 'browser'
 # bundle config --delete local.cmr_metadata_preview
 gem 'cmr_metadata_preview', git: 'https://git.earthdata.nasa.gov/scm/cmr/cmr_metadata_preview.git', ref: 'a63c41cadfa'
 
+gem 'aws-sdk-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,36 @@ GEM
     autoprefixer-rails (10.2.5.1)
       execjs (> 0)
     awrence (1.2.1)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.549.0)
+    aws-record (2.7.0)
+      aws-sdk-dynamodb (~> 1.18)
+    aws-sdk-core (3.125.5)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.525.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-dynamodb (1.70.0)
+      aws-sdk-core (~> 3, >= 3.125.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-rails (3.6.1)
+      aws-record (~> 2)
+      aws-sdk-ses (~> 1)
+      aws-sdk-sqs (~> 1)
+      aws-sessionstore-dynamodb (~> 2)
+      concurrent-ruby (~> 1)
+      railties (>= 5.2.0)
+    aws-sdk-ses (1.45.0)
+      aws-sdk-core (~> 3, >= 3.125.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-sqs (1.49.0)
+      aws-sdk-core (~> 3, >= 3.125.0)
+      aws-sigv4 (~> 1.1)
+    aws-sessionstore-dynamodb (2.0.1)
+      aws-sdk-dynamodb (~> 1)
+      rack (~> 2)
+    aws-sigv4 (1.4.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -166,6 +196,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    jmespath (1.5.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -361,6 +392,7 @@ DEPENDENCIES
   activerecord-session_store
   autoprefixer-rails
   awrence
+  aws-sdk-rails
   better_errors
   binding_of_caller
   bootstrap3-datetimepicker-rails

--- a/config/environments/dit.rb
+++ b/config/environments/dit.rb
@@ -69,7 +69,9 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV['default_url'], protocol: 'https' }
   # This domain has been configured to pass DMARC authentication.  Changing to a
   # domain which has not been will cause gmail to reject our e-mails
-  config.default_email_domain = 'earthdata.nasa.gov'
+  config.default_email_domain = 'mmt.dit.maap-project.org'
+
+  config.action_mailer.delivery_method = :ses
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/dit.rb
+++ b/config/environments/dit.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV['default_url'], protocol: 'https' }
   # This domain has been configured to pass DMARC authentication.  Changing to a
   # domain which has not been will cause gmail to reject our e-mails
-  config.default_email_domain = 'mmt.dit.maap-project.org'
+  config.default_email_domain = ENV['default_url']
 
   config.action_mailer.delivery_method = :ses
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,6 +76,8 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = ENV['default_url']
 
+  config.action_mailer.delivery_method = :ses
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,7 +84,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV['default_url'], protocol: 'https' }
   # This domain has been configured to pass DMARC authentication.  Changing to a
   # domain which has not been will cause gmail to reject our e-mails
-  config.default_email_domain = 'earthdata.nasa.gov'
+  config.default_email_domain = 'mmt.ops.maap-project.org'
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,7 +84,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV['default_url'], protocol: 'https' }
   # This domain has been configured to pass DMARC authentication.  Changing to a
   # domain which has not been will cause gmail to reject our e-mails
-  config.default_email_domain = 'mmt.ops.maap-project.org'
+  config.default_email_domain = ENV['default_url']
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/deployment/cdk/app.py
+++ b/deployment/cdk/app.py
@@ -359,6 +359,12 @@ class MmtStack(core.Stack):
             port=f"{app_service_port}"
         )
 
+        ses_permission = iam.PolicyStatement(
+            resources=["*"],
+            actions=["ses:SendRawEmail"]
+        )
+        fargate_service.task_definition.task_role.add_to_policy(ses_permission)
+
         for perm in permissions:
             fargate_service.task_definition.task_role.add_to_policy(perm)
 


### PR DESCRIPTION
I've deployed these changes to `mmt.ops` but am still waiting for confirmation that they allow emails to be sent. I couldn't figure out a good way to test that manually so I'm waiting until Sam publishes more collections via MMT