### PR TITLE
Add URS_USERNAME and URS_PASSWORD

### DIFF
--- a/deployment/cdk/app.py
+++ b/deployment/cdk/app.py
@@ -286,6 +286,10 @@ class MmtStack(core.Stack):
             self, id=f"/{stack_name}/CMR_URS_PASSWORD", parameter_name=f"/{stack_name}/CMR_URS_PASSWORD", version=1)
         secret_secret_key_base = ssm.StringParameter.from_secure_string_parameter_attributes(
             self, id=f"/{stack_name}/SECRET_KEY_BASE", parameter_name=f"/{stack_name}/SECRET_KEY_BASE", version=1)
+        secret_urs_username = ssm.StringParameter.from_secure_string_parameter_attributes(
+            self, id=f"/{stack_name}/URS_USERNAME", parameter_name=f"/{stack_name}/URS_USERNAME", version=1)
+        secret_urs_password = ssm.StringParameter.from_secure_string_parameter_attributes(
+            self, id=f"/{stack_name}/URS_PASSWORD", parameter_name=f"/{stack_name}/URS_PASSWORD", version=1)
         secret_earthdata_username = ssm.StringParameter.from_secure_string_parameter_attributes(
             self, id=f"/{stack_name}/EARTHDATA_USERNAME", parameter_name=f"/{stack_name}/EARTHDATA_USERNAME", version=1)
         secret_earthdata_password = ssm.StringParameter.from_secure_string_parameter_attributes(
@@ -311,6 +315,8 @@ class MmtStack(core.Stack):
                 "DATABASE_PASSWORD": ecs.Secret.from_secrets_manager(db_credentials_secret, "password"),
                 "CMR_URS_PASSWORD": ecs.Secret.from_ssm_parameter(secret_cmr_urs_password),
                 "SECRET_KEY_BASE": ecs.Secret.from_ssm_parameter(secret_secret_key_base),
+                "URS_PASSWORD": ecs.Secret.from_ssm_parameter(secret_urs_password),
+                "URS_USERNAME": ecs.Secret.from_ssm_parameter(secret_urs_username),
                 "EARTHDATA_PASSWORD": ecs.Secret.from_ssm_parameter(secret_earthdata_password),
                 "EARTHDATA_USERNAME": ecs.Secret.from_ssm_parameter(secret_earthdata_username),
             },


### PR DESCRIPTION
Deployment of previous PR actually caused an issue with login. When clicking the "Login with Earthdata Login" button, a "Basic Authentication: Access denied" error returned on the welcome screen. 

The logs from MMT were not informative or helpful, there was actually some red herring about the path `/actuator/health_check` not being a known route coming from middleware. I was only able to figure out this was likely the source of the issue from inspecting the code I changed in https://github.com/MAAP-Project/mmt/pull/13 and knowing that the URS_USERNAME and URS_PASSWORD were associated with the MMT application I had registered as an authorized application in uat.urs.earthdata.nasa.gov (and confusingly, the URS_USERNAME is actually the maap-mmt Client ID). However given that what I believe to rely on these credentials are these lines:

https://github.com/nasa/mmt/blob/master/lib/cmr/urs_client.rb#L98

I'm inclined to leave the variable names as currently defined.